### PR TITLE
If the executable name is `tsvtk` the `-t` option is set

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+    - If the executable/symlink name is `tsvtk` the `-t` option for tab input is set.
 - [csvtk v0.22.0](https://github.com/shenwei356/csvtk/releases/tag/v0.22.0)
 [![Github Releases (by Release)](https://img.shields.io/github/downloads/shenwei356/csvtk/v0.22.0/total.svg)](https://github.com/shenwei356/csvtk/releases/tag/v0.22.0)
     - `csvtk`: **global flag `-t` does not overide `-D` anymore**. [#114](https://github.com/shenwei356/csvtk/issues/114)

--- a/csvtk/cmd/helper.go
+++ b/csvtk/cmd/helper.go
@@ -258,6 +258,8 @@ func getConfigs(cmd *cobra.Command) Config {
 	var tabs bool
 	if val = os.Getenv("CSVTK_T"); val != "" {
 		tabs = isTrue(val)
+	} else if os.Args[0] == "tsvtk" {
+		tabs = true
 	} else {
 		tabs = getFlagBool(cmd, "tabs")
 	}


### PR DESCRIPTION
This is just a simple hack, which sets the `-t` option if the name of the executable is `tsvtk` (a symbolic link is practical).
I have found this a more flexible way to set `-t` as compared to the environmental variable.
Then it would be trivial to tweak the bioconda recipe to create a symbolic link during install with the appropriate name. 