### PR TITLE
Join option to add filename as prefix to header

### DIFF
--- a/csvtk/cmd/join.go
+++ b/csvtk/cmd/join.go
@@ -107,6 +107,7 @@ Attention:
 		}
 
 		var HeaderRow []string
+		var newColname string
 		var prefixedHeaderRow []string
 		var Data [][]string
 		var Fields []int
@@ -156,7 +157,13 @@ Attention:
 			}
 			if firstFile {
 				HeaderRow, Data, Fields = headerRow, data, fields
-				prefixedHeaderRow = headerRow
+				if filenameAsPrefix {
+					var Colname string
+					for f, Colname = range headerRow {
+						newColname = fmt.Sprintf("%s-%s", filepath.Base(file), Colname)
+						prefixedHeaderRow = append(prefixedHeaderRow, newColname)
+					}
+				}
 				firstFile = false
 				if len(HeaderRow) > 0 {
 					withHeaderRow = true
@@ -234,7 +241,6 @@ Attention:
 
 			Data2 := [][]string{}
 			var colname string
-			var newColname string
 			if withHeaderRow {
 				newHeaderRow := HeaderRow
 				for f, colname = range headerRow {

--- a/doc/docs/usage.md
+++ b/doc/docs/usage.md
@@ -1887,6 +1887,7 @@ Flags:
   -L, --left-join        left join, equals to -k/--keep-unmatched, exclusive with --outer-join
       --na string        content for filling NA data
   -O, --outer-join       outer join, exclusive with --left-join
+  -A, --prefix-filename  add each filename as a prefix to header
 
 ```
 


### PR DESCRIPTION
Hi @shenwei356 ,
<br>

I tried to implement myself the feature I requested (#202)
=> Please be aware that these are my *first ever written lines of Go*

As mentionned :
* First commit does not add prefix in 'firstFile'
* 2nd commit does (including columns used to join on)
<br>

Hope this helps !
Have nice day,
Felix.