### PR TITLE
add: support for natural log scaling of the X & Y axes

### DIFF
--- a/csvtk/cmd/box.go
+++ b/csvtk/cmd/box.go
@@ -224,6 +224,12 @@ Notes:
 		p.Y.Tick.Width = plotConfig.tickWidth
 		p.X.Tick.Label.Font.Size = plotConfig.tickLabelSize
 		p.Y.Tick.Label.Font.Size = plotConfig.tickLabelSize
+		if plotConfig.scaleLnX {
+			p.X.Scale = plot.LogScale{}
+		}
+		if plotConfig.scaleLnY {
+			p.Y.Scale = plot.LogScale{}
+		}
 
 		if plotConfig.xminStr != "" {
 			log.Warning("flag --x-min ignored for command box")

--- a/csvtk/cmd/hist.go
+++ b/csvtk/cmd/hist.go
@@ -155,6 +155,13 @@ Notes:
 		p.X.Tick.Label.Font.Size = plotConfig.tickLabelSize
 		p.Y.Tick.Label.Font.Size = plotConfig.tickLabelSize
 
+		if plotConfig.scaleLnX {
+			p.X.Scale = plot.LogScale{}
+		}
+		if plotConfig.scaleLnY {
+			p.Y.Scale = plot.LogScale{}
+		}
+
 		if plotConfig.xminStr != "" {
 			p.X.Min = plotConfig.xmin
 		}

--- a/csvtk/cmd/line.go
+++ b/csvtk/cmd/line.go
@@ -267,6 +267,13 @@ Notes:
 		p.X.Tick.Label.Font.Size = plotConfig.tickLabelSize
 		p.Y.Tick.Label.Font.Size = plotConfig.tickLabelSize
 
+		if plotConfig.scaleLnX {
+			p.X.Scale = plot.LogScale{}
+		}
+		if plotConfig.scaleLnY {
+			p.Y.Scale = plot.LogScale{}
+		}
+
 		if plotConfig.xminStr != "" {
 			p.X.Min = plotConfig.xmin
 		}

--- a/csvtk/cmd/plot.go
+++ b/csvtk/cmd/plot.go
@@ -74,6 +74,9 @@ func init() {
 	plotCmd.PersistentFlags().IntP("tick-label-size", "", 12, "tick label font size")
 	plotCmd.PersistentFlags().Float64P("scale", "", 1, "scale the image width/height, tick, axes, line/point and font sizes proportionally")
 
+	plotCmd.PersistentFlags().BoolP("x-scale-ln", "", false, "scale the X axis by the natural log")
+	plotCmd.PersistentFlags().BoolP("y-scale-ln", "", false, "scale the Y axis by the natural log")
+
 	plotCmd.PersistentFlags().StringP("format", "", "png", `image format for stdout when flag -o/--out-file not given. available values: eps, jpg|jpeg, pdf, png, svg, and tif|tiff.`)
 
 	plotCmd.PersistentFlags().StringSliceP("na-values", "", []string{"", "NA", "N/A"}, `NA values, case ignored`)
@@ -120,6 +123,9 @@ func getPlotConfigs(cmd *cobra.Command) *plotConfigs {
 
 	config.xlab = getFlagString(cmd, "xlab")
 	config.ylab = getFlagString(cmd, "ylab")
+
+	config.scaleLnX = getFlagBool(cmd, "x-scale-ln")
+	config.scaleLnY = getFlagBool(cmd, "y-scale-ln")
 
 	var err error
 
@@ -168,6 +174,7 @@ type plotConfigs struct {
 	titleSize, labelSize, tickLabelSize   vg.Length
 	width, height, axisWidth, tickWidth   vg.Length
 	scale                                 float64
+	scaleLnX, scaleLnY                    bool
 	xmin, xmax, ymin, ymax                float64
 	xminStr, xmaxStr, yminStr, ymaxStr    string
 	format                                string

--- a/doc/docs/usage.md
+++ b/doc/docs/usage.md
@@ -4433,6 +4433,8 @@ Flags:
       --y-max string          maximum value of Y axis
       --y-min string          minimum value of Y axis
       --ylab string           y label text
+      --x-scale-ln            scale the X axis with natural log
+      --y-scale-ln            scale the Y axis with natural log
 
 ```
 


### PR DESCRIPTION
This PR adds `--x-scale-ln` and `--y-scale-ln` to the `plot` command. If provided, the X &/| Y axes will be (natural) log scaled. This allows turning this:

![plot-orig](https://github.com/user-attachments/assets/4d71f1dc-a577-4dd0-a158-3dbfa46a29d1)

into this:

![plot-patch](https://github.com/user-attachments/assets/55f5c487-0a73-42a3-aed8-b86c21cde8e7)