### PR TITLE
change: if we're going to log scale the axis, we should also log scale the ticks

### DIFF
--- a/csvtk/cmd/box.go
+++ b/csvtk/cmd/box.go
@@ -226,9 +226,11 @@ Notes:
 		p.Y.Tick.Label.Font.Size = plotConfig.tickLabelSize
 		if plotConfig.scaleLnX {
 			p.X.Scale = plot.LogScale{}
+			p.X.Tick.Marker = plot.LogTicks{Prec: -1}
 		}
 		if plotConfig.scaleLnY {
 			p.Y.Scale = plot.LogScale{}
+			p.Y.Tick.Marker = plot.LogTicks{Prec: -1}
 		}
 
 		if plotConfig.xminStr != "" {

--- a/csvtk/cmd/hist.go
+++ b/csvtk/cmd/hist.go
@@ -157,9 +157,11 @@ Notes:
 
 		if plotConfig.scaleLnX {
 			p.X.Scale = plot.LogScale{}
+			p.X.Tick.Marker = plot.LogTicks{Prec: -1}
 		}
 		if plotConfig.scaleLnY {
 			p.Y.Scale = plot.LogScale{}
+			p.Y.Tick.Marker = plot.LogTicks{Prec: -1}
 		}
 
 		if plotConfig.xminStr != "" {

--- a/csvtk/cmd/line.go
+++ b/csvtk/cmd/line.go
@@ -269,9 +269,11 @@ Notes:
 
 		if plotConfig.scaleLnX {
 			p.X.Scale = plot.LogScale{}
+			p.X.Tick.Marker = plot.LogTicks{Prec: -1}
 		}
 		if plotConfig.scaleLnY {
 			p.Y.Scale = plot.LogScale{}
+			p.Y.Tick.Marker = plot.LogTicks{Prec: -1}
 		}
 
 		if plotConfig.xminStr != "" {


### PR DESCRIPTION
This was a dumb miss merely because I am not familiar with the plot API.

The ticks are now log scaled along with the graphed items. The tick _values_ were correct, they just weren't presented in log scale format, so all of the numbers were crammed off to one side.

![bplot](https://github.com/user-attachments/assets/cfdc5e89-3fa2-4ded-9fb1-1310fc45cd7b)
