### PR TITLE
Remove replace and update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ And then:
 
 #### Method 4: For Go developer (latest stable/dev version)
 
-    go get -u github.com/shenwei356/csvtk/csvtk
+    go install github.com/shenwei356/csvtk/csvtk@latest
 
 #### Method 5: For ArchLinux AUR users (may be not the latest)
 

--- a/doc/docs/download.md
+++ b/doc/docs/download.md
@@ -77,7 +77,7 @@ And then:
 
 #### Method 4: For Go developer (latest stable/dev version)
 
-    go get -u github.com/shenwei356/csvtk/csvtk
+    go install github.com/shenwei356/csvtk/csvtk@latest
 
 #### Method 5: For ArchLinux AUR users (may be not the latest)
 
@@ -100,7 +100,7 @@ And then:
 
     # ------------- the latest stable version -------------
 
-    go get -v -u github.com/shenwei356/csvtk/csvtk
+    go install github.com/shenwei356/csvtk/csvtk@latest
 
     # The executable binary file is located in:
     #   ~/go/bin/csvtk

--- a/go.mod
+++ b/go.mod
@@ -63,5 +63,3 @@ require (
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 )
-
-replace github.com/miekg/dns v1.0.14 => github.com/miekg/dns v1.1.46


### PR DESCRIPTION
The current installation docs instruct to use `go get -u github.com/shenwei356/csvtk/csvtk`. Actually that doesn't work anymore, not outside of a go project:

```
$ go get -u github.com/shenwei356/csvtk/csvtk
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Trying to install it using `go install` however doesn't work because `go.mod` contains a `replace` directive:

```
go install github.com/shenwei356/csvtk/csvtk@latest
go: github.com/shenwei356/csvtk/csvtk@latest (in github.com/shenwei356/csvtk@v0.33.0):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

I see that the `replace` directive is actually redundant, as the dependency in question is not even used. I removed the replace directive and updated the installation instructions to use `go install`, which should work after the PR is merged and a new version is released.