### PR TITLE
`csvtk summary` - fix `groups` in help message

### DIFF
--- a/csvtk/cmd/summary.go
+++ b/csvtk/cmd/summary.go
@@ -474,7 +474,7 @@ func init() {
 	sort.Strings(allStatsList)
 
 	RootCmd.AddCommand(summaryCmd)
-	summaryCmd.Flags().StringP("groups", "g", "", `group via fields. e.g -f 1,2 or -f columnA,columnB`)
+	summaryCmd.Flags().StringP("groups", "g", "", `group via fields. e.g -g 1,2 or -g columnA,columnB`)
 	summaryCmd.Flags().StringSliceP("fields", "f", []string{}, fmt.Sprintf(`operations on these fields. e.g -f 1:count,1:sum or -f colA:mean. available operations: %s`, strings.Join(allStatsList, ", ")))
 	summaryCmd.Flags().BoolP("ignore-non-numbers", "i", false, `ignore non-numeric values like "NA" or "N/A"`)
 	summaryCmd.Flags().IntP("decimal-width", "w", 2, "limit floats to N decimal points")

--- a/doc/docs/usage.md
+++ b/doc/docs/usage.md
@@ -4418,7 +4418,7 @@ Flags:
                              operations: argmax, argmin, collapse, count, countn, countuniq,
                              countunique, entropy, first, last, max, mean, median, min, prod, q1, q2,
                              q3, rand, stdev, sum, uniq, unique, variance
-  -g, --groups string        group via fields. e.g -f 1,2 or -f columnA,columnB
+  -g, --groups string        group via fields. e.g -g 1,2 or -g columnA,columnB
   -h, --help                 help for summary
   -i, --ignore-non-numbers   ignore non-numeric values like "NA" or "N/A"
   -S, --rand-seed int        rand seed for operation "rand" (default 11)


### PR DESCRIPTION
This PR fixes a minor typo in the `csvtk summary` help message (example with `-g` flag)

Thanks for the great tool!